### PR TITLE
redirecting stdout/stderr on the workbench server output to /dev/null so...

### DIFF
--- a/runtests
+++ b/runtests
@@ -3,7 +3,7 @@ echo '<<< Starting workbench server >>>'
 echo
 # Launch workbench server in the background
 cd server
-nosetests workbench &
+nosetests workbench &>/dev/null &
 # Get its PID
 workbench_pid=$!
 


### PR DESCRIPTION
... the tests don't freak out
