### PR TITLE
moving rekall based workers back into general worker pool

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     coverage combine
 
 [pytest]
-addopts= -v --doctest-modules --cov=workbench --cov-report term-missing
+addopts= -m "not rekall" -v --doctest-modules --cov=workbench --cov-report term-missing
 python_files=*.py
 python_functions=test
 norecursedirs=.tox .git timeout_corner docs *.egg-info __pycache__ images notebooks test

--- a/workbench/workers/mem_base.py
+++ b/workbench/workers/mem_base.py
@@ -45,7 +45,7 @@ class MemoryImageBase(object):
 
 # Unit test: Create the class, the proper input and run the execute() method for a test
 import pytest
-@pytest.mark.xfail
+@pytest.mark.rekall
 def test():
     ''' mem_base.py: Test '''
 

--- a/workbench/workers/mem_connscan.py
+++ b/workbench/workers/mem_connscan.py
@@ -1,25 +1,25 @@
 
-''' Memory Image DllList worker. This worker utilizes the Rekall Memory Forensic Framework.
+''' Memory Image ConnScan worker. This worker utilizes the Rekall Memory Forensic Framework.
     See Google Github: https://github.com/google/rekall
     All credit for good stuff goes to them, all credit for bad stuff goes to us. :)
 '''
 import os
 import mem_base
 
-class MemoryImageDllList(mem_base.MemoryImageBase):
-    ''' This worker computes dlllist for memory image files. '''
+class MemoryImageConnScan(mem_base.MemoryImageBase):
+    ''' This worker computes connscan-data for memory image files. '''
     dependencies = ['sample']
 
     def __init__(self):
         ''' Initialization '''
-        super(MemoryImageDllList, self).__init__()
-        self.set_plugin_name('dlllist')
+        super(MemoryImageConnScan, self).__init__()
+        self.set_plugin_name('connscan')
 
 # Unit test: Create the class, the proper input and run the execute() method for a test
 import pytest
-@pytest.mark.xfail
+@pytest.mark.rekall
 def test():
-    ''' mem_dlllist.py: Test '''
+    ''' mem_connscan.py: Test '''
 
     # This worker test requires a local server running
     import zerorpc
@@ -34,7 +34,7 @@ def test():
     input_data = c.get_sample(md5)
 
     # Execute the worker (unit test)
-    worker = MemoryImageDllList()
+    worker = MemoryImageConnScan()
     output = worker.execute(input_data)
     print '\n<<< Unit Test >>>'
     import pprint
@@ -42,7 +42,7 @@ def test():
     assert 'Error' not in output
 
     # Execute the worker (server test)
-    output = c.work_request('mem_dlllist', md5)
+    output = c.work_request('mem_connscan', md5)
     print '\n<<< Server Test >>>'
     import pprint
     pprint.pprint(output)

--- a/workbench/workers/mem_dlllist.py
+++ b/workbench/workers/mem_dlllist.py
@@ -1,25 +1,25 @@
 
-''' Memory Image ConnScan worker. This worker utilizes the Rekall Memory Forensic Framework.
+''' Memory Image DllList worker. This worker utilizes the Rekall Memory Forensic Framework.
     See Google Github: https://github.com/google/rekall
     All credit for good stuff goes to them, all credit for bad stuff goes to us. :)
 '''
 import os
 import mem_base
 
-class MemoryImageConnScan(mem_base.MemoryImageBase):
-    ''' This worker computes connscan-data for memory image files. '''
+class MemoryImageDllList(mem_base.MemoryImageBase):
+    ''' This worker computes dlllist for memory image files. '''
     dependencies = ['sample']
 
     def __init__(self):
         ''' Initialization '''
-        super(MemoryImageConnScan, self).__init__()
-        self.set_plugin_name('connscan')
+        super(MemoryImageDllList, self).__init__()
+        self.set_plugin_name('dlllist')
 
 # Unit test: Create the class, the proper input and run the execute() method for a test
 import pytest
-@pytest.mark.xfail
+@pytest.mark.rekall
 def test():
-    ''' mem_connscan.py: Test '''
+    ''' mem_dlllist.py: Test '''
 
     # This worker test requires a local server running
     import zerorpc
@@ -34,7 +34,7 @@ def test():
     input_data = c.get_sample(md5)
 
     # Execute the worker (unit test)
-    worker = MemoryImageConnScan()
+    worker = MemoryImageDllList()
     output = worker.execute(input_data)
     print '\n<<< Unit Test >>>'
     import pprint
@@ -42,7 +42,7 @@ def test():
     assert 'Error' not in output
 
     # Execute the worker (server test)
-    output = c.work_request('mem_connscan', md5)
+    output = c.work_request('mem_dlllist', md5)
     print '\n<<< Server Test >>>'
     import pprint
     pprint.pprint(output)

--- a/workbench/workers/mem_meta.py
+++ b/workbench/workers/mem_meta.py
@@ -17,7 +17,7 @@ class MemoryImageMeta(mem_base.MemoryImageBase):
 
 # Unit test: Create the class, the proper input and run the execute() method for a test
 import pytest
-@pytest.mark.xfail
+@pytest.mark.rekall
 def test():
     ''' mem_meta.py: Test '''
 

--- a/workbench/workers/mem_procdump.py
+++ b/workbench/workers/mem_procdump.py
@@ -86,7 +86,7 @@ class MemoryImageProcDump(object):
 
 # Unit test: Create the class, the proper input and run the execute() method for a test
 import pytest
-@pytest.mark.xfail
+@pytest.mark.rekall
 def test():
     ''' mem_procdump.py: Test '''
 

--- a/workbench/workers/mem_pslist.py
+++ b/workbench/workers/mem_pslist.py
@@ -17,7 +17,7 @@ class MemoryImagePSList(mem_base.MemoryImageBase):
 
 # Unit test: Create the class, the proper input and run the execute() method for a test
 import pytest
-@pytest.mark.xfail
+@pytest.mark.rekall
 def test():
     ''' mem_pslist.py: Test '''
 

--- a/workbench/workers/rekall_adapter/rekall_adapter.py
+++ b/workbench/workers/rekall_adapter/rekall_adapter.py
@@ -205,7 +205,7 @@ class WorkbenchRenderer(BaseRenderer):
 
 # Unit test: Create the class, the proper input and run the execute() method for a test
 import pytest
-@pytest.mark.xfail
+@pytest.mark.rekall
 def test():
     """rekall_adapter.py: Test."""
 


### PR DESCRIPTION
 The rekall workers are still 'mis-behaving' but now were marking them with 'rekall' test marks and excluding them from the tests (for now).
